### PR TITLE
Omega 0.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 /target/
 /build/
 /.vagrant/
+
+
 **/**.o
+**/grub.cfg
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here http://doc.crates.io/guide.html#cargotoml-vs-cargolock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ authors = ["Max Mansfield <max.m.mansfield@gmail.com>"]
 
 [dependencies]
 rlibc = "0.1.4"
+spin = "0.3.4"  #Use for temp Mutex 
 
 [lib]
 crate-type = ["staticlib"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]                     # < DO NOT CHANGE lines 1,2 or 3 to any other line
 name = "omega"
-version = "0.1.2"
+version = "0.2.0"
 # The name and version are edited in by the Makefile & because it relies on them
 # being at line 2 or 3 it is imperitive that no lines are added or removed
 # You can change anything below this comment. It is not used by the Makefile,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.2.0"
 # The name and version are edited in by the Makefile & because it relies on them
 # being at line 2 or 3 it is imperitive that no lines are added or removed
 # You can change anything below this comment. It is not used by the Makefile,
+description = "A very simple x86_64 kernel"
+repository = "https://github.com/MaxMansfield/apollo.git"
+license-file = "LICENSE"
+readme = "README.md"
 authors = ["Max Mansfield <max.m.mansfield@gmail.com>"]
 
 [dependencies]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 name ?= omega
-version ?= 0.1.2
+version ?= 0.2.0
 arch ?= x86_64
 build ?= debug
 target ?= $(arch)-unknown-linux-gnu

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Apollo
-#### Version: omega (v0.1.2)
+#### Version: omega (v0.2.0)
 <br/>
 <hr/>
 Apollo is a small x86_64 kernel written in rust
@@ -84,7 +84,7 @@ the bottom of the [Vagrantfile](https://github.com/MaxMansfield/apollo/blob/mast
 
 # Contributors and Resources
 ##### 1. **Philipp Oppermann** for [his amazing site](http://os.phil-opp.com/)
-##### 2. **intermezzOS** for [their thourough walkthrough](http://intermezzos.github.io/) 
+##### 2. **intermezzOS** for [their thourough walkthrough](http://intermezzos.github.io/)
 ##### 2. **Ashley Williams** and [her x86 repo](https://github.com/ashleygwilliams/x86-kernel) for showing me Vagrant
 
 # License (MIT)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,23 @@
 #![feature(unique)]
 #![no_std]
 extern crate rlibc;
+extern crate spin;
+
 
 ///The vgab module controls printing to the VGA buffer_ptr
+#[macro_use]
 mod vgab;
-use core::fmt::Write;
 
 #[no_mangle]
 pub extern fn kmain() {
-    // ATTENTION: we have a very small stack and no guard page
+    vgab::clear_screen();
+    kprintln!("VGA: Buffer Ready.");
 
-    vgab::write_shit();
-    loop {}
+    let mut i: i64 = 0;
+    loop {
+        kprintln!("Kernel Running! - {}", i);
+        i = i + 1;
+    }
 }
 
 #[lang = "eh_personality"] extern fn eh_personality() {}


### PR DESCRIPTION
This merge add the VGA buffer interface to the kernel.

The macros `kprint` and `kprintln` are now available to the kernel for use.
They work just like the standard rust implementations.
